### PR TITLE
Storage with a throw-away account

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockstack-storage",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "The Blockstack Javascript library for storage.",
   "main": "lib/index",
   "scripts": {

--- a/src/datastore.js
+++ b/src/datastore.js
@@ -510,6 +510,10 @@ export function datastoreMount(opts) {
       blockchain_id = opts.blockchainID;
       const app_name = opts.appName;
 
+       if (!blockchain_id){
+          blockchain_id = getSessionBlockchainID();
+       }
+
       assert(blockchain_id);
       assert(app_name);
 
@@ -530,7 +534,9 @@ export function datastoreMount(opts) {
 
    if (!blockchain_id) {
       blockchain_id = session.blockchain_id;
-      assert(blockchain_id);
+      if (!blockchain_id){
+         blockchain_id = getSessionBlockchainID();
+      }
    }
 
    if (!app_public_keys) {
@@ -675,8 +681,11 @@ function getSessionBlockchainID() {
 
    const session = jsontokens.decodeToken(userData.coreSessionToken).payload;
 
-   assert(session.blockchain_id);
-   return session.blockchain_id;
+   if (! session.blockchain_id ){
+       return 'temporary.test';
+   }else{
+       return session.blockchain_id;
+   }
 }
 
 
@@ -804,9 +813,12 @@ export function datastoreMountOrCreate(replication_strategy={'public': 1, 'local
 
    // decode
    const session = jsontokens.decodeToken(sessionToken).payload;
-   assert(session.blockchain_id);
+   var blockchain_id = session.blockchain_id;
+   if (!blockchain_id){
+       blockchain_id = getSessionBlockchainID();
+   }
 
-   let ds = getCachedMountContext(session.blockchain_id);
+   let ds = getCachedMountContext(blockchain_id);
    if (ds) {
       return new Promise((resolve, reject) => { resolve(ds); });
    }

--- a/src/datastore.js
+++ b/src/datastore.js
@@ -21,6 +21,7 @@ import {
    signDataPayload,
    signRawData,
    hashDataPayload,
+   hashRawData,
    inodeDirLink,
    inodeDirUnlink,
    decodePrivateKey,
@@ -533,10 +534,7 @@ export function datastoreMount(opts) {
    }
 
    if (!blockchain_id) {
-      blockchain_id = session.blockchain_id;
-      if (!blockchain_id){
-         blockchain_id = getSessionBlockchainID();
-      }
+      blockchain_id = getBlockchainIDFromSessionOrDefault(session);
    }
 
    if (!app_public_keys) {
@@ -668,6 +666,13 @@ function setCachedMountContext(blockchain_id, datastore_context) {
    setUserData(userData);
 }
 
+function getBlockchainIDFromSessionOrDefault(session) {
+   if (! session.blockchain_id ){
+       return hashRawData(Buffer.from(session.app_user_id).toString('base64'));
+   }else{
+       return session.blockchain_id;
+   }
+}
 
 /*
  * Get the current session's blockchain ID
@@ -681,11 +686,7 @@ function getSessionBlockchainID() {
 
    const session = jsontokens.decodeToken(userData.coreSessionToken).payload;
 
-   if (! session.blockchain_id ){
-       return 'temporary.test';
-   }else{
-       return session.blockchain_id;
-   }
+   return getBlockchainIDFromSessionOrDefault(session);
 }
 
 
@@ -813,10 +814,7 @@ export function datastoreMountOrCreate(replication_strategy={'public': 1, 'local
 
    // decode
    const session = jsontokens.decodeToken(sessionToken).payload;
-   var blockchain_id = session.blockchain_id;
-   if (!blockchain_id){
-       blockchain_id = getSessionBlockchainID();
-   }
+   var blockchain_id = getBlockchainIDFromSessionOrDefault(session);
 
    let ds = getCachedMountContext(blockchain_id);
    if (ds) {


### PR DESCRIPTION
When blockchain ID is not set (i.e., log in occurred with a throw-away account), storage-js will use `sha256(session.app_user_id)` as the temporary blockchain ID, which is the app's data store id (hashed to avoid any collisions). 